### PR TITLE
docs(repository): Configure repository metadata

### DIFF
--- a/.repository/index.json
+++ b/.repository/index.json
@@ -1,0 +1,30 @@
+{
+  "slug": "jcompiler",
+  "namespace": "jrbeverly",
+  "status": "archived",
+  "icon": "icon.svg",
+  "license": {
+    "type": "MIT",
+    "content": "Jonathan Beverly <jrbeverly>"
+  },
+  "topics": [
+    "group",
+    "joos",
+    "compiler",
+    "java",
+    "parser",
+    "lexer",
+    "ast",
+    "coursework",
+    "team"
+  ],
+  "languages": [
+    "Assembly",
+    "Dockerfile",
+    "GDB",
+    "Java",
+    "Makefile",
+    "Python",
+    "Shell"
+  ]
+}


### PR DESCRIPTION
Configure the repository metadata in code, from the github data.

Standardize the github data on topics, taglines and other properties into a repository definition file. For now this can be json instead of YAML, as that is easier to get started with. Later work can be done to convert this to a YAML format.